### PR TITLE
master

### DIFF
--- a/Firmata.package/Firmata.class/instance/openI2C..st
+++ b/Firmata.package/Firmata.class/instance/openI2C..st
@@ -1,0 +1,11 @@
+i2c
+openI2C: deviceAddress 
+	"creates and returns an I2CFirmataConnection for the specified i2c deviceAddress
+	This equivalent to the way WiringPi reifies the I2C Connection
+	and can directly be used in the ArduinoFirmataDriver of PharoThings"
+	| connection |
+	connection := I2CFirmataConnection new.
+	connection address: deviceAddress.
+	connection firmata: self.
+	self i2cConfig ."no problem that this will be executed for each I2C device"
+	^connection

--- a/Firmata.package/I2CFirmataConnection.class/README.md
+++ b/Firmata.package/I2CFirmataConnection.class/README.md
@@ -1,0 +1,8 @@
+Helper class to  implement I2C access to Firmata driver in the same way as WiringPi does, and with an equivalent protocol
+
+Instvars:
+firmata - the Firmata instance this connection belongs to (the real driver!)
+address - the address of the I2C device; this has the same role as handle in WiringPiDeviceConnection 
+readDelay - a Duration to wait before the result of a read request is read. Due to the asynchronous nature of the Firmata protocol we set it to 20 milliseconds, the smallest sample interval of a Firmata sketch.
+
+Note that Firmata I2C reads and returns byteArrays. On reading results, the first byte is the register number.

--- a/Firmata.package/I2CFirmataConnection.class/instance/address..st
+++ b/Firmata.package/I2CFirmataConnection.class/instance/address..st
@@ -1,0 +1,3 @@
+accessing
+address: anObject
+	address := anObject

--- a/Firmata.package/I2CFirmataConnection.class/instance/address.st
+++ b/Firmata.package/I2CFirmataConnection.class/instance/address.st
@@ -1,0 +1,3 @@
+accessing
+address
+	^ address

--- a/Firmata.package/I2CFirmataConnection.class/instance/close.st
+++ b/Firmata.package/I2CFirmataConnection.class/instance/close.st
@@ -1,0 +1,6 @@
+initialize-release
+close
+	"is sent by a PotDevice when disconnecting, but Firmata dos not have the concept 
+	of closing an I2C connection, so do nothing "	
+			
+	

--- a/Firmata.package/I2CFirmataConnection.class/instance/firmata..st
+++ b/Firmata.package/I2CFirmataConnection.class/instance/firmata..st
@@ -1,0 +1,3 @@
+accessing
+firmata: anObject
+	firmata := anObject

--- a/Firmata.package/I2CFirmataConnection.class/instance/firmata.st
+++ b/Firmata.package/I2CFirmataConnection.class/instance/firmata.st
@@ -1,0 +1,3 @@
+accessing
+firmata
+	^ firmata

--- a/Firmata.package/I2CFirmataConnection.class/instance/initialize.st
+++ b/Firmata.package/I2CFirmataConnection.class/instance/initialize.st
@@ -1,0 +1,4 @@
+initialization
+initialize
+	
+	readDelay := 20 milliSeconds.

--- a/Firmata.package/I2CFirmataConnection.class/instance/read16BitsAt..st
+++ b/Firmata.package/I2CFirmataConnection.class/instance/read16BitsAt..st
@@ -1,0 +1,7 @@
+i2c
+read16BitsAt: aRegister
+	| answer |
+	firmata i2cRead: address count: 2  register: aRegister .
+	readDelay wait.
+	answer := firmata i2cReadAnswer: address .
+	^(answer at: 3) * 256 + (answer at: 2)

--- a/Firmata.package/I2CFirmataConnection.class/instance/read8BitsArray.startingAt..st
+++ b/Firmata.package/I2CFirmataConnection.class/instance/read8BitsArray.startingAt..st
@@ -1,0 +1,17 @@
+accessing
+read8BitsArray: blockSize startingAt: reg
+	"this is copied from WiringPi; I think Firmata is smarter"
+"	| result bits |
+	result := ByteArray new: blockSize.
+	
+	1 to: blockSize do: [ :i | 
+		bits := self read8BitsAt: reg + i - 1.
+		result at: i put: bits].
+	
+	^result"
+	| answer |
+	firmata i2cRead: address count: blockSize register: reg.
+	readDelay wait.
+	answer := firmata i2cReadAnswer: address.
+	^answer allButFirst
+	

--- a/Firmata.package/I2CFirmataConnection.class/instance/read8BitsAt..st
+++ b/Firmata.package/I2CFirmataConnection.class/instance/read8BitsAt..st
@@ -1,0 +1,5 @@
+i2c
+read8BitsAt: aRegister
+	firmata i2cRead: address count: 1  register: aRegister .
+	readDelay wait.
+	^(firmata i2cReadAnswer: address) at: 2 "a byteArray is returned, but the first byte is the registerr number"

--- a/Firmata.package/I2CFirmataConnection.class/instance/readDelay..st
+++ b/Firmata.package/I2CFirmataConnection.class/instance/readDelay..st
@@ -1,0 +1,3 @@
+accessing
+readDelay: anObject
+	readDelay := anObject

--- a/Firmata.package/I2CFirmataConnection.class/instance/readDelay.st
+++ b/Firmata.package/I2CFirmataConnection.class/instance/readDelay.st
@@ -1,0 +1,3 @@
+accessing
+readDelay
+	^ readDelay

--- a/Firmata.package/I2CFirmataConnection.class/instance/write16BitsAt.data..st
+++ b/Firmata.package/I2CFirmataConnection.class/instance/write16BitsAt.data..st
@@ -1,0 +1,5 @@
+i2c
+write16BitsAt: aRegister data: aWord
+	firmata i2cWriteTo:  address 
+			data: (ByteArray with: aRegister with: (aWord bitAnd: 16rFF) with: (aWord // 256)).
+	readDelay wait. "To be sure the write takes effect"

--- a/Firmata.package/I2CFirmataConnection.class/instance/write8BitsAt.data..st
+++ b/Firmata.package/I2CFirmataConnection.class/instance/write8BitsAt.data..st
@@ -1,0 +1,4 @@
+i2c
+write8BitsAt: aRegister data: aByte
+	firmata i2cWriteTo:  address data: (ByteArray with: aRegister with: (aByte bitAnd: 16rFF)).
+	readDelay wait. "To be sure the write takes effect"

--- a/Firmata.package/I2CFirmataConnection.class/properties.json
+++ b/Firmata.package/I2CFirmataConnection.class/properties.json
@@ -1,0 +1,15 @@
+{
+	"commentStamp" : "RobvanLopik 9/4/2020 12:29",
+	"super" : "Object",
+	"category" : "Firmata",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"firmata",
+		"address",
+		"readDelay"
+	],
+	"name" : "I2CFirmataConnection",
+	"type" : "normal"
+}


### PR DESCRIPTION
added I2CFirmataConnection, similar to WiringPiI2CConnecction, with the same methods, so it can be used for a PotI2CDevice. Only needs a methodArduinoFirmataDriver >>> connectToI2CDevice: addr^firmata openI2C: addrTested with BME280 and my DS1307Device